### PR TITLE
Test Python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
+    - "3.7"
 install:
     - pip install -U --editable ".[dev]"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ python:
     - "3.5"
     - "3.6"
 install:
-    - "pip install -U setuptools"
-    - "python setup.py install"
-    - "pip install -U pytest mock"
+    - pip install -U --editable ".[dev]"
 script:
-    - "py.test -v"
+    - flake8 nameko_redis.py test
+    - pytest -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ services:
     - redis-server
 python:
     - "2.7"
-    - "3.3"
     - "3.4"
     - "3.5"
     - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: xenial
 services:
     - redis-server
 python:

--- a/contributors.txt
+++ b/contributors.txt
@@ -3,3 +3,5 @@ github: etataurov
 
 Fabrizio Romano <gianchub@gmail.com>
 github: gianchub
+
+Julio Trigo (@juliotrigo)

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,12 @@ setup(
         "nameko>=2.0.0",
         "redis",
     ],
+    extras_require={
+        'dev': [
+            'pytest',
+            'flake8',
+        ],
+    },
     description='Redis dependency for nameko services',
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,13 @@ setup(
     classifiers=[
         'Development Status :: 3 - Alpha',
         'License :: OSI Approved :: Apache Software License',
-
+        "Programming Language :: Python",
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )


### PR DESCRIPTION
* Add test coverage for Python 3.7
* Remove Python 3.3 support
  * It's no longer maintained
  * Travis CI fails: `Unable to download 3.3 archive.`
* Add `dev` extra packages
* Use `pip` `editable` mode
* Run `flake8` tests as part of the tests